### PR TITLE
feat(autoware_tensorrt_plugin): fuse activation, BN support

### DIFF
--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -120,7 +120,6 @@ private:
   static constexpr std::int32_t INOUT_PAIR_FWD_INDEX{2};
   static constexpr std::int32_t INOUT_PAIR_MASK_FWD_SPLITS_INDEX{3};
   static constexpr std::int32_t INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX{4};
-  /// Optional 6th input: 1D bias ``[C_out]`` (FLOAT/ HALF, same as activations). ONNX fusion only.
   static constexpr std::int32_t INOUT_OPTIONAL_BIAS_INDEX{5};
 
   void initFieldsToSerialize();

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -37,14 +37,15 @@ namespace nvinfer1::plugin
 
 struct ImplicitGemmParameters
 {
-  float act_alpha;
-  float act_beta;
-  std::int64_t is_subm;  // cSpell:ignore subm
-  std::int64_t is_train;
-  float output_add_scale;
-  float output_scale;
-  /// ``tv::gemm::Activation`` as integer (kNone=0, kReLU=1, kSigmoid=2, kLeakyReLU=3); ONNX
-  /// ``act_type`` / ``act_type_i``.
+  float act_alpha{0.0F};
+  float act_beta{0.0F};
+  std::int32_t is_subm{0};  // cSpell:ignore subm
+  std::int32_t is_train{0};
+  float output_add_scale{1.0F};
+  float output_scale{1.0F};
+
+  /// tv::gemm::Activation as integer:
+  /// kNone=0, kReLU=1, kSigmoid=2, kLeakyReLU=3.
   std::int32_t act_type{0};
 };
 

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -43,6 +43,9 @@ struct ImplicitGemmParameters
   std::int64_t is_train;
   float output_add_scale;
   float output_scale;
+  /// ``tv::gemm::Activation`` as integer (kNone=0, kReLU=1, kSigmoid=2, kLeakyReLU=3); ONNX
+  /// ``act_type`` / ``act_type_i``.
+  std::int32_t act_type{0};
 };
 
 class ImplicitGemmPlugin : public IPluginV3,
@@ -116,12 +119,15 @@ private:
   static constexpr std::int32_t INOUT_PAIR_FWD_INDEX{2};
   static constexpr std::int32_t INOUT_PAIR_MASK_FWD_SPLITS_INDEX{3};
   static constexpr std::int32_t INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX{4};
-  static constexpr std::int32_t INOUT_OUT_FEATURES_INDEX{5};
+  /// Optional 6th input: 1D bias ``[C_out]`` (FLOAT/ HALF, same as activations). ONNX fusion only.
+  static constexpr std::int32_t INOUT_OPTIONAL_BIAS_INDEX{5};
 
   void initFieldsToSerialize();
 
   std::string layer_name_;
   ImplicitGemmParameters params_;
+  /// Set in ``configurePlugin`` / ``onShapeChange``: 5 = no bias tensor, 6 = bias at input index 5.
+  std::int32_t num_plugin_inputs_{5};
   std::tuple<int, int> arch_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -29,5 +29,9 @@ void reportAssertion(bool success, char const * msg, char const * file, std::int
 
 #define PLUGIN_VALIDATE(val) reportValidation((val), #val, __FILE__, __LINE__)
 void reportValidation(bool success, char const * msg, char const * file, std::int32_t line);
+void reportValidationMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line);
+#define PLUGIN_VALIDATE_MSG(val, detail) \
+  reportValidationMsg((val), #val, (detail), __FILE__, __LINE__)
 
 #endif  // AUTOWARE__TENSORRT_PLUGINS__PLUGIN_UTILS_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -27,6 +27,10 @@ void logDebug(char const * msg);
 #define PLUGIN_ASSERT(val) reportAssertion((val), #val, __FILE__, __LINE__)
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line);
 
+#define PLUGIN_ASSERT_MSG(val, detail) reportAssertionMsg((val), #val, (detail), __FILE__, __LINE__)
+void reportAssertionMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line);
+
 #define PLUGIN_VALIDATE(val) reportValidation((val), #val, __FILE__, __LINE__)
 void reportValidation(bool success, char const * msg, char const * file, std::int32_t line);
 

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -29,9 +29,10 @@ void reportAssertion(bool success, char const * msg, char const * file, std::int
 
 #define PLUGIN_VALIDATE(val) reportValidation((val), #val, __FILE__, __LINE__)
 void reportValidation(bool success, char const * msg, char const * file, std::int32_t line);
-void reportValidationMsg(
-  bool success, char const * msg, char const * detail, char const * file, std::int32_t line);
+
 #define PLUGIN_VALIDATE_MSG(val, detail) \
   reportValidationMsg((val), #val, (detail), __FILE__, __LINE__)
+void reportValidationMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line);
 
 #endif  // AUTOWARE__TENSORRT_PLUGINS__PLUGIN_UTILS_HPP_

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -27,7 +27,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -39,36 +38,24 @@
 namespace
 {
 
-/** Spconv fused bias/add expects bias tv::Tensor dtype to match activations (see InferenceOps
- * bias_add). Keep this strict to avoid per-enqueue D2H/H2D dtype conversion overhead. */
-bool build_bias_tensor_matching_activation(
+/** Wrap the optional per-channel bias pointer into a tv::Tensor of the right dtype.
+ *
+ * Spconv fused bias/add requires the bias dtype to match the activation dtype (see InferenceOps
+ * bias_add). This avoids per-enqueue D2H/H2D dtype conversion overhead. */
+void build_bias_tensor_matching_activation(
   tv::Tensor const & input_features, void const * bias_input, std::int64_t c_bias,
-  tv::DType activation_dtype, nvinfer1::DataType bias_trt_type, cudaStream_t stream,
-  std::string const & layer_name, tv::Tensor * out_bias) noexcept
+  tv::DType activation_dtype, nvinfer1::DataType bias_trt_type, tv::Tensor * out_bias) noexcept
 {
-  (void)stream;
+  PLUGIN_ASSERT(out_bias != nullptr);
+  PLUGIN_ASSERT(activation_dtype == tv::float16 || activation_dtype == tv::float32);
   int const dev = input_features.device();
   if (activation_dtype == tv::float16) {
-    if (bias_trt_type == nvinfer1::DataType::kHALF) {
-      *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float16, dev);
-      return true;
-    }
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: optional bias dtype must be HALF for FP16 activations\n",
-      layer_name.c_str());
-    return false;
+    PLUGIN_ASSERT(bias_trt_type == nvinfer1::DataType::kHALF);
+    *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float16, dev);
+    return;
   }
-  if (activation_dtype == tv::float32) {
-    if (bias_trt_type == nvinfer1::DataType::kFLOAT) {
-      *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float32, dev);
-      return true;
-    }
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: optional bias dtype must be FLOAT for FP32 activations\n",
-      layer_name.c_str());
-    return false;
-  }
-  return false;
+  PLUGIN_ASSERT(bias_trt_type == nvinfer1::DataType::kFLOAT);
+  *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float32, dev);
 }
 
 tv::gemm::Activation activation_from_int(std::int32_t const v) noexcept
@@ -83,6 +70,7 @@ tv::gemm::Activation activation_from_int(std::int32_t const v) noexcept
     case 3:
       return tv::gemm::Activation::kLeakyReLU;
     default:
+      PLUGIN_ASSERT(false);  // should not happen
       return tv::gemm::Activation::kNone;
   }
 }
@@ -184,7 +172,8 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   std::int32_t num_outputs) noexcept
 {
   // Validate input arguments (5 = legacy; 6 = optional per-channel bias for ONNX-fused Add).
-  // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT
+  // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT for input
+  // arguments
   PLUGIN_ASSERT(in != nullptr);
   PLUGIN_ASSERT(out != nullptr);
   PLUGIN_ASSERT(num_inputs == 5 || num_inputs == 6);
@@ -220,6 +209,7 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
     DataType const bias_t = in[INOUT_OPTIONAL_BIAS_INDEX].desc.type;
     PLUGIN_ASSERT(bias_t == in[INOUT_IN_FEATURES_INDEX].desc.type);
   }
+  PLUGIN_ASSERT(params_.act_type >= 0 && params_.act_type <= 3);
 
   return 0;
 }
@@ -324,8 +314,8 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   [[maybe_unused]] auto filters_type = input_desc[INOUT_FILTERS_INDEX].type;
   [[maybe_unused]] auto out_features_type = output_desc[0].type;
 
-  assert(in_features_type == filters_type);
-  assert(in_features_type == out_features_type);
+  PLUGIN_ASSERT(in_features_type == filters_type);
+  PLUGIN_ASSERT(in_features_type == out_features_type);
 
   auto dtype = in_features_type == DataType::kFLOAT ? tv::float32 : tv::float16;
 
@@ -363,15 +353,15 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, num_out_features}, dtype, 0);
 
+  // Wrap the optional per-channel bias (BN-folded, 6th ONNX input) into a tv::Tensor.
+  // When present, spconv fuses it inside the GEMM kernel instead of a separate bias_add kernel.
+  // bias_tv stays empty (default-constructed) when there are only 5 inputs (no bias).
   tv::Tensor bias_tv{};
-  if (num_plugin_inputs_ >= 6) {
+  if (num_plugin_inputs_ == 6) {
     auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
     std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
-    if (!build_bias_tensor_matching_activation(
-          input_features, inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, stream,
-          layer_name_, &bias_tv)) {
-      return -1;
-    }
+    build_bias_tensor_matching_activation(
+      input_features, inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, &bias_tv);
   }
 
   std::vector<tv::Tensor> pair_mask_splits;
@@ -401,9 +391,8 @@ std::int32_t ImplicitGemmPlugin::onShapeChange(
   [[maybe_unused]] PluginTensorDesc const * in, std::int32_t num_inputs,
   [[maybe_unused]] PluginTensorDesc const * out, [[maybe_unused]] std::int32_t num_outputs) noexcept
 {
-  if (num_inputs == 5 || num_inputs == 6) {
-    num_plugin_inputs_ = num_inputs;
-  }
+  PLUGIN_ASSERT(num_inputs == 5 || num_inputs == 6);
+  num_plugin_inputs_ = num_inputs;
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -101,18 +101,8 @@ ImplicitGemmPlugin::ImplicitGemmPlugin(
 void ImplicitGemmPlugin::initFieldsToSerialize()
 {
   data_to_serialize_.clear();
-  data_to_serialize_.emplace_back("act_alpha", &params_.act_alpha, PluginFieldType::kFLOAT32, 1);
-  data_to_serialize_.emplace_back("act_beta", &params_.act_beta, PluginFieldType::kFLOAT32, 1);
-
   data_to_serialize_.emplace_back(
-    "is_subm", &params_.is_subm, PluginFieldType::kINT32, 1);  // cSpell:ignore subm
-  data_to_serialize_.emplace_back("is_train", &params_.is_train, PluginFieldType::kINT32, 1);
-
-  data_to_serialize_.emplace_back(
-    "output_add_scale", &params_.output_add_scale, PluginFieldType::kFLOAT32, 1);
-  data_to_serialize_.emplace_back(
-    "output_scale", &params_.output_scale, PluginFieldType::kFLOAT32, 1);
-  data_to_serialize_.emplace_back("act_type", &params_.act_type, PluginFieldType::kINT32, 1);
+    "parameters", &params_, PluginFieldType::kUNKNOWN, sizeof(ImplicitGemmParameters));
 
   fc_to_serialize_.nbFields = data_to_serialize_.size();
   fc_to_serialize_.fields = data_to_serialize_.data();

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -184,81 +184,41 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   std::int32_t num_outputs) noexcept
 {
   // Validate input arguments (5 = legacy; 6 = optional per-channel bias for ONNX-fused Add).
-  // Never abort: TensorRT probes invalid combinations during build; return an error code instead.
-  if (in == nullptr || out == nullptr) {
-    return -1;
-  }
-  if (num_inputs != 5 && num_inputs != 6) {
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: configurePlugin expected 5 or 6 inputs, got %d\n",
-      layer_name_.c_str(), static_cast<int>(num_inputs));
-    return -1;
-  }
-  if (num_outputs != 1) {
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: configurePlugin expected 1 output, got %d\n",
-      layer_name_.c_str(), static_cast<int>(num_outputs));
-    return -1;
-  }
+  // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT
+  PLUGIN_ASSERT(in != nullptr);
+  PLUGIN_ASSERT(out != nullptr);
+  PLUGIN_ASSERT(num_inputs == 5 || num_inputs == 6);
+  PLUGIN_ASSERT(num_outputs == 1);
 
   num_plugin_inputs_ = num_inputs;
 
-  if (
-    in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims != 2 ||
-    in[INOUT_FILTERS_INDEX].desc.dims.nbDims != 5 ||
-    in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims != 2 ||
-    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.nbDims != 2 ||
-    in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.nbDims != 1 || out[0].desc.dims.nbDims != 2) {
-    std::fprintf(
-      stderr,
-      "[ImplicitGemmPlugin] %s: configurePlugin unexpected tensor ranks (features/filters/pairs)\n",
-      layer_name_.c_str());
-    return -1;
-  }
-
-  if (
-    in[INOUT_FILTERS_INDEX].desc.dims.d[4] != in[INOUT_IN_FEATURES_INDEX].desc.dims.d[1] ||
-    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[0] !=
-      in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1] ||
-    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[1] != 1 ||
-    in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.d[0] !=
-      in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1]) {
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: configurePlugin dimension mismatch (pairs vs features)\n",
-      layer_name_.c_str());
-    return -1;
-  }
-
-  if (
-    in[INOUT_IN_FEATURES_INDEX].desc.type != in[INOUT_FILTERS_INDEX].desc.type ||
-    in[INOUT_IN_FEATURES_INDEX].desc.type != out[0].desc.type ||
-    in[INOUT_PAIR_FWD_INDEX].desc.type != in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.type ||
-    in[INOUT_PAIR_FWD_INDEX].desc.type != in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type) {
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: configurePlugin dtype mismatch between IO tensors\n",
-      layer_name_.c_str());
-    return -1;
-  }
+  PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(in[INOUT_FILTERS_INDEX].desc.dims.nbDims == 5);
+  PLUGIN_ASSERT(in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.nbDims == 1);
+  PLUGIN_ASSERT(out[0].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(
+    in[INOUT_FILTERS_INDEX].desc.dims.d[4] == in[INOUT_IN_FEATURES_INDEX].desc.dims.d[1]);
+  PLUGIN_ASSERT(
+    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[0] == in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1]);
+  PLUGIN_ASSERT(in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[1] == 1);
+  PLUGIN_ASSERT(
+    in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.d[0] ==
+    in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1]);
+  PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.type == in[INOUT_FILTERS_INDEX].desc.type);
+  PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.type == out[0].desc.type);
+  PLUGIN_ASSERT(
+    in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.type);
+  PLUGIN_ASSERT(
+    in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type);
 
   if (num_inputs == 6) {
-    if (
-      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.nbDims != 1 ||
-      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.d[0] != in[INOUT_FILTERS_INDEX].desc.dims.d[0]) {
-      std::fprintf(
-        stderr,
-        "[ImplicitGemmPlugin] %s: configurePlugin optional bias must be [C_out], matching filters "
-        "dim 0\n",
-        layer_name_.c_str());
-      return -1;
-    }
+    PLUGIN_ASSERT(in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.nbDims == 1);
+    PLUGIN_ASSERT(
+      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.d[0] == in[INOUT_FILTERS_INDEX].desc.dims.d[0]);
     DataType const bias_t = in[INOUT_OPTIONAL_BIAS_INDEX].desc.type;
-    if (bias_t != in[INOUT_IN_FEATURES_INDEX].desc.type) {
-      std::fprintf(
-        stderr,
-        "[ImplicitGemmPlugin] %s: configurePlugin optional bias dtype must match features dtype\n",
-        layer_name_.c_str());
-      return -1;
-    }
+    PLUGIN_ASSERT(bias_t == in[INOUT_IN_FEATURES_INDEX].desc.type);
   }
 
   return 0;
@@ -268,20 +228,11 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t pos, DynamicPluginTensorDesc const * in_out, std::int32_t num_inputs,
   std::int32_t num_outputs) noexcept
 {
-  // TRT calls this for many (pos, format) pairs; must never abort.
-  if (in_out == nullptr) {
-    return false;
-  }
-  if (num_outputs != 1) {
-    return false;
-  }
-  if (num_inputs != 5 && num_inputs != 6) {
-    return false;
-  }
+  PLUGIN_ASSERT(in_out != nullptr);
+  PLUGIN_ASSERT(num_inputs == 5 || num_inputs == 6);
+  PLUGIN_ASSERT(num_outputs == 1);
   std::int32_t const n_slots = num_inputs + num_outputs;
-  if (pos < 0 || pos >= n_slots) {
-    return false;
-  }
+  PLUGIN_ASSERT(pos >= 0 && pos < n_slots);
 
   bool supported = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
 
@@ -324,12 +275,10 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
   DataType * output_types, std::int32_t num_outputs, DataType const * input_types,
   std::int32_t num_inputs) const noexcept
 {
-  if (output_types == nullptr || input_types == nullptr) {
-    return -1;
-  }
-  if (num_outputs != 1 || (num_inputs != 5 && num_inputs != 6)) {
-    return -1;
-  }
+  PLUGIN_ASSERT(output_types != nullptr);
+  PLUGIN_ASSERT(input_types != nullptr);
+  PLUGIN_ASSERT(num_inputs == 5 || num_inputs == 6);
+  PLUGIN_ASSERT(num_outputs == 1);
 
   output_types[0] = input_types[INOUT_IN_FEATURES_INDEX];
 
@@ -342,15 +291,11 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
   DimsExprs * outputs, std::int32_t num_outputs,
   [[maybe_unused]] IExprBuilder & expr_builder) noexcept
 {
-  if (inputs == nullptr || outputs == nullptr) {
-    return -1;
-  }
-  if (num_outputs != 1 || (num_inputs != 5 && num_inputs != 6)) {
-    return -1;
-  }
-  if (inputs[0].nbDims != 2) {
-    return -1;
-  }
+  PLUGIN_ASSERT(inputs != nullptr);
+  PLUGIN_ASSERT(outputs != nullptr);
+  PLUGIN_ASSERT(num_inputs == 5 || num_inputs == 6);
+  PLUGIN_ASSERT(num_outputs == 1);
+  PLUGIN_ASSERT(inputs[0].nbDims == 2);
 
   outputs[0].nbDims = 2;
   outputs[0].d[0] = inputs[3].d[0];
@@ -367,14 +312,7 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
 
-  if (num_plugin_inputs_ != 5 && num_plugin_inputs_ != 6) {
-    std::fprintf(
-      stderr,
-      "[ImplicitGemmPlugin] %s: enqueue expected 5 or 6 inputs (set in configure/onShapeChange), "
-      "got num_plugin_inputs_=%d\n",
-      layer_name_.c_str(), static_cast<int>(num_plugin_inputs_));
-    return -1;
-  }
+  PLUGIN_ASSERT(num_plugin_inputs_ == 5 || num_plugin_inputs_ == 6);
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
@@ -386,12 +324,8 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   [[maybe_unused]] auto filters_type = input_desc[INOUT_FILTERS_INDEX].type;
   [[maybe_unused]] auto out_features_type = output_desc[0].type;
 
-  if (in_features_type != filters_type || in_features_type != out_features_type) {
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: enqueue dtype mismatch (features/filters/out)\n",
-      layer_name_.c_str());
-    return -1;
-  }
+  assert(in_features_type == filters_type);
+  assert(in_features_type == out_features_type);
 
   auto dtype = in_features_type == DataType::kFLOAT ? tv::float32 : tv::float16;
 
@@ -422,15 +356,10 @@ std::int32_t ImplicitGemmPlugin::enqueue(
     },
     tv::int32, 0);
 
-  if (
-    input_desc[INOUT_PAIR_FWD_INDEX].dims.d[1] !=
-      input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.d[0] ||
-    input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.nbDims != 1) {
-    std::fprintf(
-      stderr, "[ImplicitGemmPlugin] %s: enqueue invalid pair/mask-argsort tensor shape\n",
-      layer_name_.c_str());
-    return -1;
-  }
+  PLUGIN_ASSERT(
+    input_desc[INOUT_PAIR_FWD_INDEX].dims.d[1] ==
+    input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.d[0]);
+  PLUGIN_ASSERT(input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.nbDims == 1);
 
   tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, num_out_features}, dtype, 0);
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -18,7 +18,6 @@
 
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
-#include <cuda_runtime_api.h>
 #include <spconvlib/spconv/csrc/sparse/all/SpconvOps.h>  // cSpell:ignore spconvlib
 #include <spconvlib/spconv/csrc/sparse/alloc/StaticAllocator.h>
 #include <spconvlib/spconv/csrc/sparse/convops/SimpleExternalSpconvMatmul.h>

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -171,7 +171,9 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   DynamicPluginTensorDesc const * in, std::int32_t num_inputs, DynamicPluginTensorDesc const * out,
   std::int32_t num_outputs) noexcept
 {
-  // Validate input arguments (5 = legacy; 6 = optional per-channel bias for ONNX-fused Add).
+  // Validate input arguments.
+  // 5 inputs: standard implicit GEMM path without fused bias.
+  // 6 inputs: implicit GEMM path with optional per-channel bias.
   // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT for input
   // arguments
   PLUGIN_ASSERT(in != nullptr);

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -18,6 +18,7 @@
 
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
+#include <cuda_runtime_api.h>
 #include <spconvlib/spconv/csrc/sparse/all/SpconvOps.h>  // cSpell:ignore spconvlib
 #include <spconvlib/spconv/csrc/sparse/alloc/StaticAllocator.h>
 #include <spconvlib/spconv/csrc/sparse/convops/SimpleExternalSpconvMatmul.h>
@@ -26,6 +27,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -33,6 +35,58 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+namespace
+{
+
+/** Spconv fused bias/add expects bias tv::Tensor dtype to match activations (see InferenceOps
+ * bias_add). Keep this strict to avoid per-enqueue D2H/H2D dtype conversion overhead. */
+bool build_bias_tensor_matching_activation(
+  tv::Tensor const & input_features, void const * bias_input, std::int64_t c_bias,
+  tv::DType activation_dtype, nvinfer1::DataType bias_trt_type, cudaStream_t stream,
+  std::string const & layer_name, tv::Tensor * out_bias) noexcept
+{
+  (void)stream;
+  int const dev = input_features.device();
+  if (activation_dtype == tv::float16) {
+    if (bias_trt_type == nvinfer1::DataType::kHALF) {
+      *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float16, dev);
+      return true;
+    }
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: optional bias dtype must be HALF for FP16 activations\n",
+      layer_name.c_str());
+    return false;
+  }
+  if (activation_dtype == tv::float32) {
+    if (bias_trt_type == nvinfer1::DataType::kFLOAT) {
+      *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float32, dev);
+      return true;
+    }
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: optional bias dtype must be FLOAT for FP32 activations\n",
+      layer_name.c_str());
+    return false;
+  }
+  return false;
+}
+
+tv::gemm::Activation activation_from_int(std::int32_t const v) noexcept
+{
+  switch (v) {
+    case 0:
+      return tv::gemm::Activation::kNone;
+    case 1:
+      return tv::gemm::Activation::kReLU;
+    case 2:
+      return tv::gemm::Activation::kSigmoid;
+    case 3:
+      return tv::gemm::Activation::kLeakyReLU;
+    default:
+      return tv::gemm::Activation::kNone;
+  }
+}
+}  // namespace
 
 namespace nvinfer1::plugin
 {
@@ -60,7 +114,7 @@ void ImplicitGemmPlugin::initFieldsToSerialize()
 {
   data_to_serialize_.clear();
   data_to_serialize_.emplace_back("act_alpha", &params_.act_alpha, PluginFieldType::kFLOAT32, 1);
-  data_to_serialize_.emplace_back("act_alpha", &params_.act_beta, PluginFieldType::kFLOAT32, 1);
+  data_to_serialize_.emplace_back("act_beta", &params_.act_beta, PluginFieldType::kFLOAT32, 1);
 
   data_to_serialize_.emplace_back(
     "is_subm", &params_.is_subm, PluginFieldType::kINT32, 1);  // cSpell:ignore subm
@@ -70,6 +124,7 @@ void ImplicitGemmPlugin::initFieldsToSerialize()
     "output_add_scale", &params_.output_add_scale, PluginFieldType::kFLOAT32, 1);
   data_to_serialize_.emplace_back(
     "output_scale", &params_.output_scale, PluginFieldType::kFLOAT32, 1);
+  data_to_serialize_.emplace_back("act_type", &params_.act_type, PluginFieldType::kINT32, 1);
 
   fc_to_serialize_.nbFields = data_to_serialize_.size();
   fc_to_serialize_.fields = data_to_serialize_.data();
@@ -95,7 +150,8 @@ IPluginCapability * ImplicitGemmPlugin::getCapabilityInterface(PluginCapabilityT
 IPluginV3 * ImplicitGemmPlugin::clone() noexcept
 {
   try {
-    IPluginV3 * const plugin{new ImplicitGemmPlugin{layer_name_, params_}};
+    ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{layer_name_, params_}};
+    plugin->num_plugin_inputs_ = num_plugin_inputs_;
     return plugin;
   } catch (std::exception const & e) {
     caughtError(e);
@@ -127,29 +183,83 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   DynamicPluginTensorDesc const * in, std::int32_t num_inputs, DynamicPluginTensorDesc const * out,
   std::int32_t num_outputs) noexcept
 {
-  // Validate input arguments.
-  PLUGIN_ASSERT(num_inputs == 5);
-  PLUGIN_ASSERT(num_outputs == 1);
-  PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims == 2);
-  PLUGIN_ASSERT(in[INOUT_FILTERS_INDEX].desc.dims.nbDims == 5);
-  PLUGIN_ASSERT(in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims == 2);
-  PLUGIN_ASSERT(in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.nbDims == 2);
-  PLUGIN_ASSERT(in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.nbDims == 1);
-  PLUGIN_ASSERT(out[0].desc.dims.nbDims == 2);
-  PLUGIN_ASSERT(
-    in[INOUT_FILTERS_INDEX].desc.dims.d[4] == in[INOUT_IN_FEATURES_INDEX].desc.dims.d[1]);
-  PLUGIN_ASSERT(
-    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[0] == in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1]);
-  PLUGIN_ASSERT(in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[1] == 1);
-  PLUGIN_ASSERT(
-    in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.d[0] ==
-    in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1]);
-  PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.type == in[INOUT_FILTERS_INDEX].desc.type);
-  PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.type == out[0].desc.type);
-  PLUGIN_ASSERT(
-    in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.type);
-  PLUGIN_ASSERT(
-    in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type);
+  // Validate input arguments (5 = legacy; 6 = optional per-channel bias for ONNX-fused Add).
+  // Never abort: TensorRT probes invalid combinations during build; return an error code instead.
+  if (in == nullptr || out == nullptr) {
+    return -1;
+  }
+  if (num_inputs != 5 && num_inputs != 6) {
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: configurePlugin expected 5 or 6 inputs, got %d\n",
+      layer_name_.c_str(), static_cast<int>(num_inputs));
+    return -1;
+  }
+  if (num_outputs != 1) {
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: configurePlugin expected 1 output, got %d\n",
+      layer_name_.c_str(), static_cast<int>(num_outputs));
+    return -1;
+  }
+
+  num_plugin_inputs_ = num_inputs;
+
+  if (
+    in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims != 2 ||
+    in[INOUT_FILTERS_INDEX].desc.dims.nbDims != 5 ||
+    in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims != 2 ||
+    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.nbDims != 2 ||
+    in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.nbDims != 1 || out[0].desc.dims.nbDims != 2) {
+    std::fprintf(
+      stderr,
+      "[ImplicitGemmPlugin] %s: configurePlugin unexpected tensor ranks (features/filters/pairs)\n",
+      layer_name_.c_str());
+    return -1;
+  }
+
+  if (
+    in[INOUT_FILTERS_INDEX].desc.dims.d[4] != in[INOUT_IN_FEATURES_INDEX].desc.dims.d[1] ||
+    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[0] !=
+      in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1] ||
+    in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.d[1] != 1 ||
+    in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.d[0] !=
+      in[INOUT_PAIR_FWD_INDEX].desc.dims.d[1]) {
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: configurePlugin dimension mismatch (pairs vs features)\n",
+      layer_name_.c_str());
+    return -1;
+  }
+
+  if (
+    in[INOUT_IN_FEATURES_INDEX].desc.type != in[INOUT_FILTERS_INDEX].desc.type ||
+    in[INOUT_IN_FEATURES_INDEX].desc.type != out[0].desc.type ||
+    in[INOUT_PAIR_FWD_INDEX].desc.type != in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.type ||
+    in[INOUT_PAIR_FWD_INDEX].desc.type != in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type) {
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: configurePlugin dtype mismatch between IO tensors\n",
+      layer_name_.c_str());
+    return -1;
+  }
+
+  if (num_inputs == 6) {
+    if (
+      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.nbDims != 1 ||
+      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.d[0] != in[INOUT_FILTERS_INDEX].desc.dims.d[0]) {
+      std::fprintf(
+        stderr,
+        "[ImplicitGemmPlugin] %s: configurePlugin optional bias must be [C_out], matching filters "
+        "dim 0\n",
+        layer_name_.c_str());
+      return -1;
+    }
+    DataType const bias_t = in[INOUT_OPTIONAL_BIAS_INDEX].desc.type;
+    if (bias_t != in[INOUT_IN_FEATURES_INDEX].desc.type) {
+      std::fprintf(
+        stderr,
+        "[ImplicitGemmPlugin] %s: configurePlugin optional bias dtype must match features dtype\n",
+        layer_name_.c_str());
+      return -1;
+    }
+  }
 
   return 0;
 }
@@ -158,10 +268,28 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t pos, DynamicPluginTensorDesc const * in_out, std::int32_t num_inputs,
   std::int32_t num_outputs) noexcept
 {
-  PLUGIN_ASSERT(num_inputs == 5);
-  PLUGIN_ASSERT(num_outputs == 1);
+  // TRT calls this for many (pos, format) pairs; must never abort.
+  if (in_out == nullptr) {
+    return false;
+  }
+  if (num_outputs != 1) {
+    return false;
+  }
+  if (num_inputs != 5 && num_inputs != 6) {
+    return false;
+  }
+  std::int32_t const n_slots = num_inputs + num_outputs;
+  if (pos < 0 || pos >= n_slots) {
+    return false;
+  }
 
   bool supported = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
+
+  std::int32_t const out_pos = num_inputs;
+  if (pos == out_pos) {
+    supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+    return supported;
+  }
 
   switch (pos) {
     case INOUT_IN_FEATURES_INDEX:
@@ -170,13 +298,19 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
          in_out[pos].desc.type == nvinfer1::DataType::kHALF);
       break;
     case INOUT_FILTERS_INDEX:
-    case INOUT_OUT_FEATURES_INDEX:
       supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
       break;
     case INOUT_PAIR_FWD_INDEX:
     case INOUT_PAIR_MASK_FWD_SPLITS_INDEX:
     case INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX:
       supported &= in_out[pos].desc.type == nvinfer1::DataType::kINT32;
+      break;
+    case INOUT_OPTIONAL_BIAS_INDEX:
+      if (num_inputs == 6) {
+        supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+      } else {
+        supported = false;
+      }
       break;
     default:
       supported = false;
@@ -190,8 +324,12 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
   DataType * output_types, std::int32_t num_outputs, DataType const * input_types,
   std::int32_t num_inputs) const noexcept
 {
-  PLUGIN_ASSERT(num_inputs == 5);
-  PLUGIN_ASSERT(num_outputs == 1);
+  if (output_types == nullptr || input_types == nullptr) {
+    return -1;
+  }
+  if (num_outputs != 1 || (num_inputs != 5 && num_inputs != 6)) {
+    return -1;
+  }
 
   output_types[0] = input_types[INOUT_IN_FEATURES_INDEX];
 
@@ -204,9 +342,15 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
   DimsExprs * outputs, std::int32_t num_outputs,
   [[maybe_unused]] IExprBuilder & expr_builder) noexcept
 {
-  PLUGIN_ASSERT(num_inputs == 5);
-  PLUGIN_ASSERT(num_outputs == 1);
-  PLUGIN_ASSERT(inputs[0].nbDims == 2);
+  if (inputs == nullptr || outputs == nullptr) {
+    return -1;
+  }
+  if (num_outputs != 1 || (num_inputs != 5 && num_inputs != 6)) {
+    return -1;
+  }
+  if (inputs[0].nbDims != 2) {
+    return -1;
+  }
 
   outputs[0].nbDims = 2;
   outputs[0].d[0] = inputs[3].d[0];
@@ -223,6 +367,15 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
 
+  if (num_plugin_inputs_ != 5 && num_plugin_inputs_ != 6) {
+    std::fprintf(
+      stderr,
+      "[ImplicitGemmPlugin] %s: enqueue expected 5 or 6 inputs (set in configure/onShapeChange), "
+      "got num_plugin_inputs_=%d\n",
+      layer_name_.c_str(), static_cast<int>(num_plugin_inputs_));
+    return -1;
+  }
+
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
   // std::int64_t kernel_volume = input_desc[INOUT_PAIR_FWD_INDEX].dims.d[0];
@@ -231,10 +384,14 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   auto in_features_type = input_desc[INOUT_IN_FEATURES_INDEX].type;
   [[maybe_unused]] auto filters_type = input_desc[INOUT_FILTERS_INDEX].type;
-  [[maybe_unused]] auto out_features_type = input_desc[INOUT_OUT_FEATURES_INDEX].type;
+  [[maybe_unused]] auto out_features_type = output_desc[0].type;
 
-  assert(in_features_type == filters_type);
-  assert(in_features_type == out_features_type);
+  if (in_features_type != filters_type || in_features_type != out_features_type) {
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: enqueue dtype mismatch (features/filters/out)\n",
+      layer_name_.c_str());
+    return -1;
+  }
 
   auto dtype = in_features_type == DataType::kFLOAT ? tv::float32 : tv::float16;
 
@@ -265,12 +422,28 @@ std::int32_t ImplicitGemmPlugin::enqueue(
     },
     tv::int32, 0);
 
-  PLUGIN_ASSERT(
-    input_desc[INOUT_PAIR_FWD_INDEX].dims.d[1] ==
-    input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.d[0]);
-  PLUGIN_ASSERT(input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.nbDims == 1);
+  if (
+    input_desc[INOUT_PAIR_FWD_INDEX].dims.d[1] !=
+      input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.d[0] ||
+    input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.nbDims != 1) {
+    std::fprintf(
+      stderr, "[ImplicitGemmPlugin] %s: enqueue invalid pair/mask-argsort tensor shape\n",
+      layer_name_.c_str());
+    return -1;
+  }
 
   tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, num_out_features}, dtype, 0);
+
+  tv::Tensor bias_tv{};
+  if (num_plugin_inputs_ >= 6) {
+    auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
+    std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
+    if (!build_bias_tensor_matching_activation(
+          input_features, inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, stream,
+          layer_name_, &bias_tv)) {
+      return -1;
+    }
+  }
 
   std::vector<tv::Tensor> pair_mask_splits;
   std::vector<tv::Tensor> mask_argsort_splits;
@@ -286,19 +459,22 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   auto & tuner_ptr = dtype == tv::float32 ? tuner_fp32_ptr_ : tuner_fp16_ptr_;
 
-  auto conv_run_status = ConvGemmOps::implicit_gemm(
+  [[maybe_unused]] auto const conv_run_status = ConvGemmOps::implicit_gemm(
     alloc2, *tuner_ptr, input_features, weights, pair_fwd, pair_mask_splits, mask_argsort_splits,
     num_act_out, mask_tensor_, arch_, false, params_.is_subm,
-    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, tv::Tensor(),
-    0.0, 0.0, tv::gemm::Activation::kNone, false, 1.0, tv::Tensor(), tv::Tensor(), 0.0, -1);
-
+    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, bias_tv,
+    params_.act_alpha, params_.act_beta, activation_from_int(params_.act_type), false, 1.0,
+    tv::Tensor(), tv::Tensor(), 0.0, -1);
   return 0;
 }
 
 std::int32_t ImplicitGemmPlugin::onShapeChange(
-  [[maybe_unused]] PluginTensorDesc const * in, [[maybe_unused]] std::int32_t num_inputs,
+  [[maybe_unused]] PluginTensorDesc const * in, std::int32_t num_inputs,
   [[maybe_unused]] PluginTensorDesc const * out, [[maybe_unused]] std::int32_t num_outputs) noexcept
 {
+  if (num_inputs == 5 || num_inputs == 6) {
+    num_plugin_inputs_ = num_inputs;
+  }
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -59,7 +59,8 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
   auto parse_expanded_fields = [](
                                  nvinfer1::PluginField const * fields, std::int32_t num_fields,
                                  ImplicitGemmParameters & parameters) {
-    PLUGIN_VALIDATE(num_fields >= 6 && num_fields <= 7);
+    // support additional field for act_type
+    PLUGIN_VALIDATE(num_fields == 6 || num_fields == 7);
     for (std::int32_t i{0}; i < num_fields; ++i) {
       const std::string attr_name = fields[i].name;
       const nvinfer1::PluginFieldType type = fields[i].type;
@@ -97,6 +98,7 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
       if (attr_name == "act_type") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
         parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
+        PLUGIN_VALIDATE(parameters.act_type >= 0 && parameters.act_type <= 3);
       }
     }
   };
@@ -113,35 +115,11 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
 
       // Log the attributes parsed from ONNX node.
       std::stringstream ss;
-      ss << name << " plugin Attributes:";
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "act_alpha: " << parameters.act_alpha;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "act_beta: " << parameters.act_beta;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "is_subm: " << parameters.is_subm;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "is_train: " << parameters.is_train;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "output_add_scale: " << parameters.output_add_scale;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "output_scale: " << parameters.output_scale;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "act_type: " << parameters.act_type;
+      ss << name << " plugin Attributes:"
+         << " act_alpha=" << parameters.act_alpha << " act_beta=" << parameters.act_beta
+         << " is_subm=" << parameters.is_subm << " is_train=" << parameters.is_train
+         << " output_add_scale=" << parameters.output_add_scale
+         << " output_scale=" << parameters.output_scale << " act_type=" << parameters.act_type;
       logDebug(ss.str().c_str());
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), parameters}};

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -121,7 +121,7 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
-      PLUGIN_VALIDATE_MSG(
+      PLUGIN_ASSERT_MSG(
         num_fields == 1,
         "Unsupported serialized plugin format. The plugin I/O contract has changed. "
         "Please rebuild the TensorRT engine.");

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -56,6 +56,51 @@ nvinfer1::PluginFieldCollection const * ImplicitGemmPluginCreator::getFieldNames
 IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
   char const * name, PluginFieldCollection const * fc, TensorRTPhase phase) noexcept
 {
+  auto parse_expanded_fields = [](
+                                 nvinfer1::PluginField const * fields, std::int32_t num_fields,
+                                 ImplicitGemmParameters & parameters) {
+    PLUGIN_VALIDATE(num_fields >= 6 && num_fields <= 7);
+    for (std::int32_t i{0}; i < num_fields; ++i) {
+      const std::string attr_name = fields[i].name;
+      const nvinfer1::PluginFieldType type = fields[i].type;
+
+      if (attr_name == "act_alpha") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.act_alpha = static_cast<float const *>(fields[i].data)[0];
+      }
+
+      if (attr_name == "act_beta") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.act_beta = static_cast<float const *>(fields[i].data)[0];
+      }
+
+      if (attr_name == "is_subm") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.is_subm = static_cast<std::int32_t const *>(fields[i].data)[0];
+      }
+
+      if (attr_name == "is_train") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.is_train = static_cast<std::int32_t const *>(fields[i].data)[0];
+      }
+
+      if (attr_name == "output_add_scale") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.output_add_scale = static_cast<float const *>(fields[i].data)[0];
+      }
+
+      if (attr_name == "output_scale") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
+      }
+
+      if (attr_name == "act_type") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
+      }
+    }
+  };
+
   // The build phase and the deserialization phase are handled differently.
   if (phase == TensorRTPhase::kBUILD) {
     // The attributes from the ONNX node will be parsed and passed via fc.
@@ -63,49 +108,8 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
 
-      PLUGIN_VALIDATE(num_fields >= 6 && num_fields <= 7);
-
       ImplicitGemmParameters parameters{};
-
-      for (std::int32_t i{0}; i < num_fields; ++i) {
-        const std::string attr_name = fields[i].name;
-        const nvinfer1::PluginFieldType type = fields[i].type;
-
-        if (attr_name == "act_alpha") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.act_alpha = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "act_beta") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.act_beta = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "is_subm") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
-          parameters.is_subm = static_cast<std::int32_t const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "is_train") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
-          parameters.is_train = static_cast<std::int32_t const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "output_add_scale") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.output_add_scale = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "output_scale") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "act_type") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
-          parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
-        }
-      }
+      parse_expanded_fields(fields, num_fields, parameters);
 
       // Log the attributes parsed from ONNX node.
       std::stringstream ss;
@@ -151,13 +155,17 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
-      PLUGIN_VALIDATE(num_fields == 1);
-
-      char const * attr_name = fields[0].name;
-      PLUGIN_VALIDATE(!strcmp(attr_name, "parameters"));
-      PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kUNKNOWN);
-      PLUGIN_VALIDATE(fields[0].length == sizeof(ImplicitGemmParameters));
-      ImplicitGemmParameters params{*(static_cast<ImplicitGemmParameters const *>(fields[0].data))};
+      ImplicitGemmParameters params{};
+      // Backward compatibility:
+      // - Legacy runtime serialization: one packed "parameters" blob (kUNKNOWN)
+      // - Current runtime serialization: expanded per-attribute plugin fields
+      if (num_fields == 1 && fields[0].name != nullptr && !strcmp(fields[0].name, "parameters")) {
+        PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kUNKNOWN);
+        PLUGIN_VALIDATE(fields[0].length == sizeof(ImplicitGemmParameters));
+        params = *(static_cast<ImplicitGemmParameters const *>(fields[0].data));
+      } else {
+        parse_expanded_fields(fields, num_fields, params);
+      }
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), params}};
       return plugin;

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -68,34 +68,22 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
       if (attr_name == "act_alpha") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
         parameters.act_alpha = static_cast<float const *>(fields[i].data)[0];
-      }
-
-      if (attr_name == "act_beta") {
+      } else if (attr_name == "act_beta") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
         parameters.act_beta = static_cast<float const *>(fields[i].data)[0];
-      }
-
-      if (attr_name == "is_subm") {
+      } else if (attr_name == "is_subm") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
         parameters.is_subm = static_cast<std::int32_t const *>(fields[i].data)[0];
-      }
-
-      if (attr_name == "is_train") {
+      } else if (attr_name == "is_train") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
         parameters.is_train = static_cast<std::int32_t const *>(fields[i].data)[0];
-      }
-
-      if (attr_name == "output_add_scale") {
+      } else if (attr_name == "output_add_scale") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
         parameters.output_add_scale = static_cast<float const *>(fields[i].data)[0];
-      }
-
-      if (attr_name == "output_scale") {
+      } else if (attr_name == "output_scale") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
         parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
-      }
-
-      if (attr_name == "act_type") {
+      } else if (attr_name == "act_type") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
         parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
         PLUGIN_VALIDATE(parameters.act_type >= 0 && parameters.act_type <= 3);
@@ -133,17 +121,16 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
-      ImplicitGemmParameters params{};
-      // Backward compatibility:
-      // - Legacy runtime serialization: one packed "parameters" blob (kUNKNOWN)
-      // - Current runtime serialization: expanded per-attribute plugin fields
-      if (num_fields == 1 && fields[0].name != nullptr && !strcmp(fields[0].name, "parameters")) {
-        PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kUNKNOWN);
-        PLUGIN_VALIDATE(fields[0].length == sizeof(ImplicitGemmParameters));
-        params = *(static_cast<ImplicitGemmParameters const *>(fields[0].data));
-      } else {
-        parse_expanded_fields(fields, num_fields, params);
-      }
+      // Runtime deserialization only supports the current packed parameter format.
+      // Engines built with older plugin I/O contracts are not supported.
+      // Please rebuild the TensorRT engine.
+      PLUGIN_VALIDATE(num_fields == 1);
+      PLUGIN_VALIDATE(fields[0].name != nullptr);
+      PLUGIN_VALIDATE(!strcmp(fields[0].name, "parameters"));
+      PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kUNKNOWN);
+      PLUGIN_VALIDATE(fields[0].length == sizeof(ImplicitGemmParameters));
+      PLUGIN_VALIDATE(fields[0].data != nullptr);
+      auto params = *(static_cast<ImplicitGemmParameters const *>(fields[0].data));
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), params}};
       return plugin;

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -131,7 +131,6 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
       PLUGIN_VALIDATE(fields[0].length == sizeof(ImplicitGemmParameters));
       PLUGIN_VALIDATE(fields[0].data != nullptr);
       auto params = *(static_cast<ImplicitGemmParameters const *>(fields[0].data));
-
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), params}};
       return plugin;
     } catch (std::exception const & e) {

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -41,6 +41,7 @@ ImplicitGemmPluginCreator::ImplicitGemmPluginCreator()
   plugin_attributes_.emplace_back("is_train", nullptr, PluginFieldType::kINT32, 1);
   plugin_attributes_.emplace_back("output_add_scale", nullptr, PluginFieldType::kFLOAT32, 1);
   plugin_attributes_.emplace_back("output_scale", nullptr, PluginFieldType::kFLOAT32, 1);
+  plugin_attributes_.emplace_back("act_type", nullptr, PluginFieldType::kINT32, 1);
 
   fc_.nbFields = plugin_attributes_.size();
   fc_.fields = plugin_attributes_.data();
@@ -56,15 +57,15 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
   char const * name, PluginFieldCollection const * fc, TensorRTPhase phase) noexcept
 {
   // The build phase and the deserialization phase are handled differently.
-  if (phase == TensorRTPhase::kBUILD || phase == TensorRTPhase::kRUNTIME) {
+  if (phase == TensorRTPhase::kBUILD) {
     // The attributes from the ONNX node will be parsed and passed via fc.
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
 
-      PLUGIN_VALIDATE(num_fields == 6);
+      PLUGIN_VALIDATE(num_fields >= 6 && num_fields <= 7);
 
-      ImplicitGemmParameters parameters;
+      ImplicitGemmParameters parameters{};
 
       for (std::int32_t i{0}; i < num_fields; ++i) {
         const std::string attr_name = fields[i].name;
@@ -99,6 +100,11 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
           PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
           parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
         }
+
+        if (attr_name == "act_type") {
+          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+          parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
+        }
       }
 
       // Log the attributes parsed from ONNX node.
@@ -128,6 +134,10 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
 
       ss.str("");
       ss << "output_scale: " << parameters.output_scale;
+      logDebug(ss.str().c_str());
+
+      ss.str("");
+      ss << "act_type: " << parameters.act_type;
       logDebug(ss.str().c_str());
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), parameters}};

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -121,10 +121,10 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
-      // Runtime deserialization only supports the current packed parameter format.
-      // Engines built with older plugin I/O contracts are not supported.
-      // Please rebuild the TensorRT engine.
-      PLUGIN_VALIDATE(num_fields == 1);
+      PLUGIN_VALIDATE_MSG(
+        num_fields == 1,
+        "Unsupported serialized plugin format. The plugin I/O contract has changed. "
+        "Please rebuild the TensorRT engine.");
       PLUGIN_VALIDATE(fields[0].name != nullptr);
       PLUGIN_VALIDATE(!strcmp(fields[0].name, "parameters"));
       PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kUNKNOWN);

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -20,6 +20,33 @@
 #include <cstring>
 #include <sstream>
 
+namespace
+{
+void logAssertionFailure(
+  char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  std::ostringstream stream;
+  stream << "Assertion failed: " << msg << std::endl;
+  if (detail != nullptr && std::strlen(detail) > 0) {
+    stream << detail << std::endl;
+  }
+  stream << file << ':' << line << std::endl << "Aborting..." << std::endl;
+  getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+}
+
+void logValidationFailure(
+  char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  std::ostringstream stream;
+  stream << "Validation failed: " << msg << std::endl;
+  if (detail != nullptr && std::strlen(detail) > 0) {
+    stream << detail << std::endl;
+  }
+  stream << file << ':' << line << std::endl;
+  getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+}
+}  // namespace
+
 void caughtError(std::exception const & e)
 {
   getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, e.what());
@@ -33,11 +60,16 @@ void logDebug(char const * msg)
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {
-    std::ostringstream stream;
-    stream << "Assertion failed: " << msg << std::endl
-           << file << ':' << line << std::endl
-           << "Aborting..." << std::endl;
-    getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+    logAssertionFailure(msg, nullptr, file, line);
+    std::abort();
+  }
+}
+
+void reportAssertionMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  if (!success) {
+    logAssertionFailure(msg, detail, file, line);
     std::abort();
   }
 }
@@ -45,9 +77,7 @@ void reportAssertion(bool success, char const * msg, char const * file, std::int
 void reportValidation(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {
-    std::ostringstream stream;
-    stream << "Validation failed: " << msg << std::endl << file << ':' << line << std::endl;
-    getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+    logValidationFailure(msg, nullptr, file, line);
   }
 }
 
@@ -55,12 +85,6 @@ void reportValidationMsg(
   bool success, char const * msg, char const * detail, char const * file, std::int32_t line)
 {
   if (!success) {
-    std::ostringstream stream;
-    stream << "Validation failed: " << msg << std::endl;
-    if (detail != nullptr && std::strlen(detail) > 0) {
-      stream << detail << std::endl;
-    }
-    stream << file << ':' << line << std::endl;
-    getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+    logValidationFailure(msg, detail, file, line);
   }
 }

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -50,3 +50,17 @@ void reportValidation(bool success, char const * msg, char const * file, std::in
     getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
   }
 }
+
+void reportValidationMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  if (!success) {
+    std::ostringstream stream;
+    stream << "Validation failed: " << msg << std::endl;
+    if (detail != nullptr && std::strlen(detail) > 0) {
+      stream << detail << std::endl;
+    }
+    stream << file << ':' << line << std::endl;
+    getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+  }
+}


### PR DESCRIPTION
## Description

This PR extends `ImplicitGemmPlugin` to support fused bias and activation in the spconv implicit GEMM path.

The main motivation is to reduce extra TensorRT kernels generated after sparse convolution, especially for BN-folded bias/add and activation patterns. When the ONNX graph provides an optional per-channel bias as the 6th input, the plugin now forwards it directly to spconv’s `implicit_gemm` implementation, allowing the bias to be fused inside the GEMM kernel instead of being executed as a separate operation.

## Changes

- Added optional 6th plugin input for per-channel bias:
  - 5 inputs: standard implicit GEMM path without bias.
  - 6 inputs: implicit GEMM path with fused bias.
- Added `act_type` to `ImplicitGemmParameters` to support fused activation:
  - `0`: None
  - `1`: ReLU
  - `2`: Sigmoid
  - `3`: LeakyReLU
- Added helper logic to wrap the optional bias input as a `tv::Tensor` with the same dtype as the activation tensor.
- Updated `ConvGemmOps::implicit_gemm()` to pass:
  - optional bias tensor
  - activation alpha / beta
  - activation type
- Updated plugin format and type validation to support both 5-input and 6-input paths.
- Changed plugin parameter serialization to use a packed `ImplicitGemmParameters` blob.
- Added assertion and validation message helpers for clearer plugin error logs.
- Improved the deserialization error message when an old or incompatible TensorRT engine is used.

## Notes

- This change updates the plugin serialization format.
- Existing TensorRT engines built with the previous plugin version are not compatible and must be rebuilt.
- The plugin now supports ONNX graphs where BatchNorm folding introduces a per-channel bias tensor after sparse convolution.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
